### PR TITLE
ClientInfoの設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ Flutter Plugin for PAY.JP SDK is available under the MIT license. See the LICENS
 ### Generate models
 
 See generator/README.md.
+
+### Bump up version
+
+```bash
+tool/bump_version.sh [NEW_VERSION]
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,11 +22,11 @@
  */
 
 group 'jp.pay.flutter'
-version '0.1.4'
+version VERSION_NAME
 
 buildscript {
     ext.kotlin_version = '1.3.61'
-    ext.payjpSdkVersion = '1.1.2'
+    ext.payjpSdkVersion = '1.1.3'
 
     repositories {
         google()
@@ -58,12 +58,10 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
+        versionName VERSION_NAME
     }
     lintOptions {
         disable 'InvalidPackage'
-    }
-    libraryVariants.all {
-        it.generateBuildConfig.enabled = false
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -30,3 +30,5 @@ org.gradle.caching=true
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
+
+VERSION_NAME=0.1.4

--- a/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
+++ b/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
@@ -42,6 +42,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 import jp.pay.android.Payjp
 import jp.pay.android.PayjpConfiguration
 import jp.pay.android.cardio.PayjpCardScannerPlugin
+import jp.pay.android.model.ClientInfo
 import jp.pay.android.model.TenantId
 import java.util.Locale
 
@@ -109,12 +110,17 @@ class PayjpFlutterPlugin: MethodCallHandler, FlutterPlugin, ActivityAware {
       val locale = call.argument<String>("locale")?.let { tag ->
         LocaleListCompat.forLanguageTags(tag).takeIf { it.size() > 0 }?.get(0)
       } ?: Locale.getDefault()
+      val clientInfo = ClientInfo.Builder()
+        .setPlugin("${BuildConfig.LIBRARY_PACKAGE_NAME}/${BuildConfig.VERSION_NAME}")
+        .setPublisher("payjp")
+        .build()
       activateModernTls(debugEnabled)
       Payjp.init(PayjpConfiguration.Builder(publicKey = publicKey)
         .setDebugEnabled(debugEnabled)
         .setTokenBackgroundHandler(cardFormModule)
         .setLocale(locale)
         .setCardScannerPlugin(PayjpCardScannerPlugin)
+        .setClientInfo(clientInfo)
         .build())
       result.success(null)
     }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - CardIO (5.4.1)
   - Flutter (1.0.0)
-  - PAYJP (1.1.3)
+  - PAYJP (1.1.4)
   - payjp_flutter (0.1.4):
     - CardIO (~> 5.4.1)
     - Flutter
-    - PAYJP (~> 1.1.3)
+    - PAYJP (~> 1.1.4)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -25,8 +25,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  PAYJP: ea303727b00d4d27c240741630251ea3db2e3cd1
-  payjp_flutter: e9dab6e97ab537fe5bb7fd24278d271fc59ee8a7
+  PAYJP: b2107cd450ab864c6005ed1d8602b2975f15538a
+  payjp_flutter: 2db17742602b0f3bdd7bcc4b36d72c1b311981f4
 
 PODFILE CHECKSUM: 1b66dae606f75376c5f2135a8290850eeb09ae83
 

--- a/ios/Classes/PayjpPluginConstant.swift
+++ b/ios/Classes/PayjpPluginConstant.swift
@@ -1,0 +1,16 @@
+//
+//  PayjpPluginConstant.swift
+//  payjp_flutter
+//
+//  Created by Tatsuya Kitagawa on 2020/02/12.
+//
+
+import Foundation
+
+struct PayjpPluginConstant {
+
+    private init() {
+    }
+
+    static let PluginVersion: String = "0.1.4"
+}

--- a/ios/Classes/SwiftPayjpFlutterPlugin.swift
+++ b/ios/Classes/SwiftPayjpFlutterPlugin.swift
@@ -8,6 +8,9 @@ public class SwiftPayjpFlutterPlugin: NSObject, FlutterPlugin {
         let instance = SwiftPayjpFlutterPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
+    private static var pluginVersion: String {
+        return Bundle(for: SwiftPayjpFlutterPlugin.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+    }
     private let channel: FlutterMethodChannel
     private let cardFormModule: CardFormModuleType
     private let applePayModule: ApplePayModule
@@ -33,6 +36,7 @@ public class SwiftPayjpFlutterPlugin: NSObject, FlutterPlugin {
                 } else {
                     PAYJPSDK.locale = Locale.current
                 }
+                PAYJPSDK.clientInfo = ClientInfo.makeInfo(plugin: "jp.pay.flutter/\(SwiftPayjpFlutterPlugin.pluginVersion)", publisher: "payjp")
             }
             result(nil)
             break

--- a/ios/Classes/SwiftPayjpFlutterPlugin.swift
+++ b/ios/Classes/SwiftPayjpFlutterPlugin.swift
@@ -8,9 +8,6 @@ public class SwiftPayjpFlutterPlugin: NSObject, FlutterPlugin {
         let instance = SwiftPayjpFlutterPlugin(channel: channel)
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
-    private static var pluginVersion: String {
-        return Bundle(for: SwiftPayjpFlutterPlugin.self).infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-    }
     private let channel: FlutterMethodChannel
     private let cardFormModule: CardFormModuleType
     private let applePayModule: ApplePayModule
@@ -36,7 +33,7 @@ public class SwiftPayjpFlutterPlugin: NSObject, FlutterPlugin {
                 } else {
                     PAYJPSDK.locale = Locale.current
                 }
-                PAYJPSDK.clientInfo = ClientInfo.makeInfo(plugin: "jp.pay.flutter/\(SwiftPayjpFlutterPlugin.pluginVersion)", publisher: "payjp")
+                PAYJPSDK.clientInfo = ClientInfo.makeInfo(plugin: "jp.pay.flutter/\(PayjpPluginConstant.PluginVersion)", publisher: "payjp")
             }
             result(nil)
             break

--- a/ios/payjp_flutter.podspec
+++ b/ios/payjp_flutter.podspec
@@ -16,7 +16,7 @@ A Flutter plugin for PAY.JP Mobile SDK.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.static_framework = true
-  s.dependency 'PAYJP', '~> 1.1.3'
+  s.dependency 'PAYJP', '~> 1.1.4'
   s.dependency 'CardIO', '~> 5.4.1'
   s.dependency 'Flutter'
 

--- a/tool/bump_version.sh
+++ b/tool/bump_version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -ex
+ROOT="$(git rev-parse --show-toplevel)"
+
+if [ $# -ne 1 ]; then
+  echo 'Error: Missing argument' 1>&2
+  echo "Usage: ${0} NEW_VERSION" 1>&2
+  exit 1
+fi
+NEW_VERSION=$1
+
+# pubspec.yaml
+PUBSPEC="$ROOT/pubspec.yaml"
+NEW_VERSION_PUBSPEC="version: $NEW_VERSION"
+sed -i '' -e "s/version: .*/$NEW_VERSION_PUBSPEC/g" $PUBSPEC
+
+# podspec
+PODSPEC="$ROOT/ios/payjp_flutter.podspec"
+NEW_VERSION_PODSPEC="s.version          = '$NEW_VERSION'"
+sed -i '' -e "s/s.version.*/$NEW_VERSION_PODSPEC/g" $PODSPEC
+
+# ios constants
+IOS_CONST="$ROOT/ios/Classes/PayjpPluginConstant.swift"
+NEW_VERSION_IOS_CONST="static let PluginVersion: String = \"$NEW_VERSION\""
+sed -i '' -e "s/static let PluginVersion: String =.*/$NEW_VERSION_IOS_CONST/g" $IOS_CONST
+
+# gradle.properties
+GRADLEP="$ROOT/android/gradle.properties"
+NEW_VERSION_GRADLEP="VERSION_NAME=$NEW_VERSION"
+sed -i '' -e "s/VERSION_NAME=.*/$NEW_VERSION_GRADLEP/g" $GRADLEP
+
+exit $?


### PR DESCRIPTION
- payjp-android を 1.1.3 に更新
- payjp-ios を 1.1.4 に更新
- ClientInfoに `jp.pay.flutter` を設定

~pluginのバージョンを上げる際は以下の変更をします。（改善の余地あり）~
- ~pubspec.yamlのversionを変更~
- ~android/gradle.properties のVERSION_NAMEを変更~
- ~ios/payjp_flutter.podspec の versionを変更~

`tool/bump_version.sh` を実行すると全部更新されるようにしました。