### PR TITLE
Prefer conditional member access to ternary operator.

### DIFF
--- a/lib/src/payjp.dart
+++ b/lib/src/payjp.dart
@@ -128,12 +128,12 @@ class Payjp {
   /// by default.
   static Future init(
       {@required String publicKey,
-      bool debugEnabled = false,
+      bool debugEnabled,
       Locale locale}) async {
     final params = <String, dynamic>{
       'publicKey': publicKey,
-      'debugEnabled': debugEnabled,
-      'locale': locale != null ? locale.toLanguageTag() : null,
+      'debugEnabled': debugEnabled ?? false,
+      'locale': locale?.toLanguageTag(),
     };
     await _channel.invokeMethod('initialize', params);
   }
@@ -188,7 +188,7 @@ class Payjp {
       @required String countryCode,
       @required String summaryItemLabel,
       @required String summaryItemAmount,
-      bool requiredBillingAddress = false,
+      bool requiredBillingAddress,
       OnApplePayProducedTokenCallback onApplePayProducedTokenCallback,
       OnApplePayFailedRequestTokenCallback onApplePayFailedRequestTokenCallback,
       OnApplePayCompletedCallback onApplePayCompletedCallback}) async {
@@ -202,7 +202,7 @@ class Payjp {
       'countryCode': countryCode,
       'summaryItemLabel': summaryItemLabel,
       'summaryItemAmount': summaryItemAmount,
-      'requiredBillingAddress': requiredBillingAddress
+      'requiredBillingAddress': requiredBillingAddress ?? false
     };
     await _channel.invokeMethod('makeApplePayToken', params);
   }


### PR DESCRIPTION
`?.` Conditional member access
https://dart.dev/guides/language/language-tour#other-operators

- Use conditional member access instead of ternary operator (e.g. `foo ? foo.bar : null`)
- Use `??` operator instead of default argument for null safety.


