### PR TITLE
String literal instead of BuildConfig.LIBRARY_PACKAGE_NAME.

### DIFF
--- a/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
+++ b/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
@@ -111,7 +111,7 @@ class PayjpFlutterPlugin: MethodCallHandler, FlutterPlugin, ActivityAware {
         LocaleListCompat.forLanguageTags(tag).takeIf { it.size() > 0 }?.get(0)
       } ?: Locale.getDefault()
       val clientInfo = ClientInfo.Builder()
-        .setPlugin("${BuildConfig.LIBRARY_PACKAGE_NAME}/${BuildConfig.VERSION_NAME}")
+        .setPlugin("jp.pay.flutter/${BuildConfig.VERSION_NAME}")
         .setPublisher("payjp")
         .build()
       activateModernTls(debugEnabled)


### PR DESCRIPTION
`BuildConfig.LIBRARY_PACKAGE_NAME` is too early.