### PR TITLE
Specify supported platforms.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,5 +21,9 @@ dev_dependencies:
 
 flutter:
   plugin:
-    androidPackage: jp.pay.flutter
-    pluginClass: PayjpFlutterPlugin
+    platforms:
+      android:
+        package: jp.pay.flutter
+        pluginClass: PayjpFlutterPlugin
+      ios:
+        pluginClass: PayjpFlutterPlugin


### PR DESCRIPTION
cf. https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms

> In Flutter 1.10 and later, plugins can specify the platforms they support by adding keys to the platforms map in the pubspec.yaml file. For example the following is the flutter: map for the “hello” plugin:
> 
> ```
> flutter:
>   plugin:
>     platforms:
>       android:
>         package: com.example.hello
>         pluginClass: HelloPlugin
>       ios:
>         pluginClass: HelloPlugin
> 
> environment:
>   sdk: ">=2.1.0 <3.0.0"
>   # Flutter versions prior to 1.10 did not support the flutter.plugin.platforms map.
>   flutter: ">=1.10.0 <2.0.0"
> ```