### PR TITLE
Fix onCardFormCanceled not called.

### DIFF
--- a/ios/Classes/CardFormModule.swift
+++ b/ios/Classes/CardFormModule.swift
@@ -45,6 +45,7 @@ class CardFormModule: CardFormModuleType {
                 navigationController.pushViewController(cardForm, animated: true)
             } else {
                 let navigationController = UINavigationController.init(rootViewController: cardForm)
+                navigationController.presentationController?.delegate = cardForm
                 hostViewController.present(navigationController, animated: true, completion: nil)
             }
         }


### PR DESCRIPTION
iOS13以上の `UIModalPresentationStyle` がpagesheetでスワイプでmodalを閉じるときonCardFormCanceledCallbackが呼ばれないのを修正