### PR TITLE
Check pod outdated

### DIFF
--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -1,0 +1,21 @@
+name: Check dependencies outdated
+
+on: push
+
+jobs:
+  check_outdated:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: yatatsu/pod-outdated-check-action@v0.2.0
+        id: outdated
+        with:
+          project_directory: example/ios
+          podspec: ios/payjp_flutter.podspec
+          exclude_pods: Flutter
+      - name: Create Issue
+        if: steps.outdated.outputs.has_any_outdated != 'false'
+        run: |
+          hub issue create -m "Found outdated dependencies." -m "${{ steps.outdated.outputs.outdated_pod_info }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -12,6 +12,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
       - run: flutter pub get
+      - run: cd example/ios && pod install
       - uses: yatatsu/pod-outdated-check-action@v0.2.0
         id: outdated
         with:

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -14,6 +14,14 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
       - run: flutter pub get
+      - name: Cache Cocoapods
+        uses: actions/cache@v2
+        id: pods-cache
+        with:
+          path: example/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('example/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - run: cd example/ios && pod install
       - uses: yatatsu/pod-outdated-check-action@v0.3.0
         id: outdated

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: subosito/flutter-action@v1
       - run: flutter pub get
       - run: cd example/ios && pod install
-      - uses: yatatsu/pod-outdated-check-action@v0.2.0
+      - uses: yatatsu/pod-outdated-check-action@v0.3.0
         id: outdated
         with:
           project_directory: example/ios

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -1,6 +1,8 @@
 name: Check dependencies outdated
 
-on: push
+on:
+  schedule:
+    - cron: 0 0 * * 1-5
 
 jobs:
   check_outdated:
@@ -18,7 +20,7 @@ jobs:
         with:
           project_directory: example/ios
           podspec: ios/payjp_flutter.podspec
-          exclude_pods: Flutter
+          exclude_pods: Flutter,PAYJPFlutterCore
       - name: Create Issue
         if: steps.outdated.outputs.has_any_outdated != 'false'
         run: |

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -2,7 +2,7 @@ name: Check dependencies outdated
 
 on:
   schedule:
-    - cron: 0 0 * * 1-5
+    - cron: 0 0 * * 1
 
 jobs:
   check_outdated:

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -7,6 +7,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '12.x'
+      - uses: subosito/flutter-action@v1
+      - run: flutter pub get
       - uses: yatatsu/pod-outdated-check-action@v0.2.0
         id: outdated
         with:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,26 +3,28 @@ PODS:
   - e2e (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - GoogleUtilities/AppDelegateSwizzler (6.5.2):
+  - GoogleUtilities/AppDelegateSwizzler (6.7.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.5.2)
-  - GoogleUtilities/Logger (6.5.2):
+  - GoogleUtilities/Environment (6.7.2):
+    - PromisesObjC (~> 1.2)
+  - GoogleUtilities/Logger (6.7.2):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (6.5.2):
+  - GoogleUtilities/Network (6.7.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.5.2)"
-  - GoogleUtilities/Reachability (6.5.2):
+  - "GoogleUtilities/NSData+zlib (6.7.2)"
+  - GoogleUtilities/Reachability (6.7.2):
     - GoogleUtilities/Logger
   - payjp_flutter (0.2.3):
     - CardIO (~> 5.4.1)
     - Flutter
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.5.2)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
     - PAYJPFlutterCore (~> 1.2.5)
   - PAYJPFlutterCore (1.2.5)
+  - PromisesObjC (1.2.10)
 
 DEPENDENCIES:
   - e2e (from `.symlinks/plugins/e2e/ios`)
@@ -34,6 +36,7 @@ SPEC REPOS:
     - CardIO
     - GoogleUtilities
     - PAYJPFlutterCore
+    - PromisesObjC
 
 EXTERNAL SOURCES:
   e2e:
@@ -47,10 +50,11 @@ SPEC CHECKSUMS:
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   e2e: d0c9f8c832b4cc7ab386d0c0f0af67fe5ac0c3bd
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
-  payjp_flutter: 77fb661772592cb1fd8997f4fec21582f4772fed
+  GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
+  payjp_flutter: 73236ae1f56c03162af1ef589e9c5d81d37595f2
   PAYJPFlutterCore: a852bd90024cf3665e978b39a5a9687392d9d56c
+  PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
 
 PODFILE CHECKSUM: 3b5f041287da2a6a8f6ca19d22f5852fb5857496
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 				"${PODS_ROOT}/../Flutter/Flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/PAYJPFlutterCore/PAYJP.framework",
+				"${BUILT_PRODUCTS_DIR}/PromisesObjC/FBLPromises.framework",
 				"${BUILT_PRODUCTS_DIR}/e2e/e2e.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -234,6 +235,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PAYJP.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBLPromises.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/e2e.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/payjp_flutter.podspec
+++ b/ios/payjp_flutter.podspec
@@ -22,7 +22,7 @@ A Flutter plugin for PAY.JP Mobile SDK.
   s.static_framework = true
   s.dependency 'PAYJPFlutterCore', "~> #{payjp_sdk['ios']}"
   s.dependency 'CardIO', '~> 5.4.1'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.5.2'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
   s.dependency 'Flutter'
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }


### PR DESCRIPTION
Fix #23 

# Overview

- To prevent cocoapods resolution problem, added scheduled-workflow that checks outdated deps of `payjp_flutter.podspec`. 
- Run [`pod outdated`](https://guides.cocoapods.org/terminal/commands.html#pod_outdated) weekly.
- Use https://github.com/yatatsu/pod-outdated-check-action.
- If any outdated deps found, create a issue (like #23).

# Related

https://github.com/payjp/payjp-react-native-plugin/pull/74