### PR TITLE
Fix usage of AppDelegateSwizzler

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -137,8 +137,8 @@ jobs:
         run: xcrun simctl list devices available | grep "iPhone"
       - name: Start iOS Simulator
         run: |
-          UDID=$(xcrun simctl list devices available --json | jq '.devices."com.apple.CoreSimulator.SimRuntime.${{ env.IOS_SIMULATOR_RUNTIME }}"[] | select(.name == "${{ env.IOS_SIMULATOR_DEVICE }}").udid')
-          xcrun simctl boot ${UDID}
+          UDID=$(xcrun simctl list devices available --json | jq -r '.devices."com.apple.CoreSimulator.SimRuntime.${{ env.IOS_SIMULATOR_RUNTIME }}"[] | select(.name == "${{ env.IOS_SIMULATOR_DEVICE }}").udid')
+          xcrun simctl boot "${UDID}"
       - name: Run e2e test
         run: make driver-test
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,7 +10,8 @@ on:
 env:
   FLUTTER_CHANNEL: stable
   CACHE_NUMBER: 0 # increment to truncate cache
-  IOS_SIMULATOR_NAME: iPhone 11 Pro Max (13.7)
+  IOS_SIMULATOR_DEVICE: iPhone 11 Pro Max
+  IOS_SIMULATOR_RUNTIME: iOS-14-0
   USER_JAVA_VERSION: 8.x
 
 jobs:
@@ -133,10 +134,10 @@ jobs:
         run: make build-ios-example
       # connected check
       - name: List all iPhone Simulator
-        run: xcrun instruments -s | grep iPhone
+        run: xcrun simctl list devices available | grep "iPhone"
       - name: Start iOS Simulator
         run: |
-          UDID=$(xcrun instruments -s | awk -F ' *[][]' -v 'device=${{ env.IOS_SIMULATOR_NAME }}' '$1 == device { print $2 }')
+          UDID=$(xcrun simctl list devices available --json | jq '.devices."com.apple.CoreSimulator.SimRuntime.${{ env.IOS_SIMULATOR_RUNTIME }}"[] | select(.name == "${{ env.IOS_SIMULATOR_DEVICE }}").udid')
           xcrun simctl boot "${UDID}"
       - name: Run e2e test
         run: make driver-test

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Start iOS Simulator
         run: |
           UDID=$(xcrun simctl list devices available --json | jq '.devices."com.apple.CoreSimulator.SimRuntime.${{ env.IOS_SIMULATOR_RUNTIME }}"[] | select(.name == "${{ env.IOS_SIMULATOR_DEVICE }}").udid')
-          xcrun simctl boot "${UDID}"
+          xcrun simctl boot ${UDID}
       - name: Run e2e test
         run: make driver-test
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 *.ipr
 *.iws
 .idea/
+example/ios/Flutter/.last_build_id

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,28 +3,28 @@ PODS:
   - e2e (0.0.1):
     - Flutter
   - Flutter (1.0.0)
-  - GoogleUtilities/AppDelegateSwizzler (6.7.2):
+  - GoogleUtilities/AppDelegateSwizzler (7.0.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.7.2):
+  - GoogleUtilities/Environment (7.0.0):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.7.2):
+  - GoogleUtilities/Logger (7.0.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/Network (6.7.2):
+  - GoogleUtilities/Network (7.0.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.7.2)"
-  - GoogleUtilities/Reachability (6.7.2):
+  - "GoogleUtilities/NSData+zlib (7.0.0)"
+  - GoogleUtilities/Reachability (7.0.0):
     - GoogleUtilities/Logger
   - payjp_flutter (0.2.4):
     - CardIO (~> 5.4.1)
     - Flutter
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.7)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - PAYJPFlutterCore (~> 1.3.0)
   - PAYJPFlutterCore (1.3.0)
-  - PromisesObjC (1.2.10)
+  - PromisesObjC (1.2.11)
 
 DEPENDENCIES:
   - e2e (from `.symlinks/plugins/e2e/ios`)
@@ -50,10 +50,10 @@ SPEC CHECKSUMS:
   CardIO: 56983b39b62f495fc6dae9ad7cf875143df06443
   e2e: d0c9f8c832b4cc7ab386d0c0f0af67fe5ac0c3bd
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3
-  payjp_flutter: 8a0c9f0258b1c176dc4b3579c1923524b43df6b2
+  GoogleUtilities: ffb2f4159f2c897c6e8992bd7fbcdef8a300589c
+  payjp_flutter: 9fe02282f1775116ec9bb14fc270f628737ef8e2
   PAYJPFlutterCore: f402dd95056a39230823e87bf1abf94215dbf065
-  PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
+  PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
 
 PODFILE CHECKSUM: 33f74cf6f4e5775ad35ae5df4008ad34eb3f5e59
 

--- a/ios/Classes/PayjpAppDelegateInterceptor.m
+++ b/ios/Classes/PayjpAppDelegateInterceptor.m
@@ -38,11 +38,25 @@
 }
 
 - (BOOL)application:(UIApplication *)application
-            openURL:(NSURL *)URL
+            openURL:(NSURL *)url
             options:(NSDictionary<NSString *, id> *)options {
-  BOOL result =
-      [[PAYJPThreeDSecureProcessHandler sharedHandler] completeThreeDSecureProcessWithUrl:URL];
-  return result;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  return [self application:application
+                   openURL:url
+         sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+                annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+#pragma clang diagnostic pop
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (BOOL)application:(UIApplication *)application
+              openURL:(NSURL *)url
+    sourceApplication:(NSString *)sourceApplication
+           annotation:(id)annotation {
+  return [[PAYJPThreeDSecureProcessHandler sharedHandler] completeThreeDSecureProcessWithUrl:url];
+}
+#pragma clang diagnostic pop
 
 @end

--- a/ios/payjp_flutter.podspec
+++ b/ios/payjp_flutter.podspec
@@ -22,7 +22,7 @@ A Flutter plugin for PAY.JP Mobile SDK.
   s.static_framework = true
   s.dependency 'PAYJPFlutterCore', "~> #{payjp_sdk['ios']}"
   s.dependency 'CardIO', '~> 5.4.1'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 7.0'
   s.dependency 'Flutter'
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }


### PR DESCRIPTION
Fix #28 

- Update `GoogleUtilities/AppDelegateSwizzler` to 7.0
  - https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/CHANGELOG.md#700
- Fix ignoring interceptor because of missing implementation of `application:openURL:sourceApplication:annotation`.
  - https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/AppDelegateSwizzler/README.md