### PR TITLE
Update AGP to 4.1.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -66,7 +66,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        versionName VERSION_NAME
+        buildConfigField "String", "VERSION_NAME", "\"$VERSION_NAME\""
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -29,6 +29,5 @@ org.gradle.caching=true
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true
 
 VERSION_NAME=0.2.7

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -25,4 +25,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -53,6 +53,8 @@ android {
 
     lintOptions {
         disable 'InvalidPackage'
+        // FIXME: workaround for https://github.com/flutter/flutter/issues/58247
+        checkReleaseBuilds false
     }
 
     defaultConfig {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -29,4 +29,3 @@ org.gradle.caching=true
 
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 13 16:33:29 JST 2020
+#Tue Dec 15 17:17:48 JST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip


### PR DESCRIPTION
Android Gradle Plugin 4.1.0以降、ライブラリプロジェクトの `VERSION_NAME` はBuildConfigから削除されるため、ビルドに失敗する。

https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects

buildConfigFieldを使って明示的にVERSION_NAMEをBuildConfigに設定するよう変更した。