### PR TITLE
Token作成エラーのメッセージがiOSで表示されないのを修正

### DIFF
--- a/ios/Classes/TokenStoringError.swift
+++ b/ios/Classes/TokenStoringError.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 struct TokenStoringError: LocalizedError {
-    let errorDescription: String
+    let errorDescription: String?
 }


### PR DESCRIPTION
LocalizedErrorなカスタムエラーの errorDescriptionの型が違っていたためメッセージが意図した形で表示されていなかったのを修正。


|Before|After|
|-|-|
|<img src=https://user-images.githubusercontent.com/949882/114508894-dd1e8580-9c6f-11eb-8ae4-70928423e43b.png width=300 />|<img src=https://user-images.githubusercontent.com/949882/114508741-ae081400-9c6f-11eb-9ab4-2c7a425271dc.png width=300 />|