### PR TITLE
Rename VERSION_NAME to avoid a conflict in old AGP

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 28
-        buildConfigField "String", "VERSION_NAME", "\"$VERSION_NAME\""
+        buildConfigField "String", "LIBRARY_VERSION_NAME", "\"$VERSION_NAME\""
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
+++ b/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
@@ -112,7 +112,7 @@ class PayjpFlutterPlugin: MethodCallHandler, FlutterPlugin, ActivityAware {
         LocaleListCompat.forLanguageTags(tag).takeIf { it.size() > 0 }?.get(0)
       } ?: Locale.getDefault()
       val clientInfo = ClientInfo.Builder()
-        .setPlugin("jp.pay.flutter/${BuildConfig.VERSION_NAME}")
+        .setPlugin("jp.pay.flutter/${BuildConfig.LIBRARY_VERSION_NAME}")
         .setPublisher("payjp")
         .build()
       val tdsRedirectKey = call.argument<String>("threeDSecureRedirectKey")


### PR DESCRIPTION
- #37 でAGP 4.1.1に対応した際に明示的に VERSION_NAME をBuildConfigに追加した
- 古いAGPだとVERSION_NAMEはBuildConfigに自動で追加されるため、衝突が起きてビルドエラーになる
- あえて衝突させる理由もないので別の名前を割り当てる