### PR TITLE
build-testアクションのFLUTTER_VERSIONを3.27.4に固定する

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   FLUTTER_CHANNEL: stable
+  FLUTTER_VERSION: 3.27.4
   CACHE_NUMBER: 0 # increment to truncate cache
   IOS_SIMULATOR_DEVICE: iPhone 15 Pro
   IOS_SIMULATOR_RUNTIME: iOS-17-5
@@ -56,7 +57,8 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: ${{ env.FLUTTER_CHANNEL }}
-      - uses: gradle/actions/setup-gradle@v3
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+      - uses: gradle/actions/setup-gradle@v4
       - name: Cache Flutter
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## 変更点
-  FLUTTER_CHANNEL: stable = 現在の最新バージョンになっている設定を3.27.4に固定します
- 2/13/2015時点の3.29.0に未対応のため：https://docs.flutter.dev/release/archive
- 直接関連しないですがgradle/actions/setup-gradle@v4のバージョンアップも適用します