### PR TITLE
[0.7.4]Android embedding v1 APIの削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.4
+
+- Remove deprecated Registrar usage in Android embedding v1 classes. #87
+
 ## 0.7.3
 
 - Update payjp-ios to [2.1.5](https://github.com/payjp/payjp-ios/releases/tag/2.1.5).

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -30,4 +30,4 @@ org.gradle.caching=true
 android.useAndroidX=true
 android.enableJetifier=true
 
-VERSION_NAME=0.7.3
+VERSION_NAME=0.7.4

--- a/android/src/main/kotlin/jp/pay/flutter/CardFormModule.kt
+++ b/android/src/main/kotlin/jp/pay/flutter/CardFormModule.kt
@@ -44,8 +44,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 
 internal class CardFormModule(
-    private val channel: MethodChannel,
-    private val register: PluginRegistry.Registrar?
+    private val channel: MethodChannel
 ) : PayjpTokenBackgroundHandler, PluginRegistry.ActivityResultListener {
 
     private val requestCodeCardForm = 13015
@@ -59,11 +58,7 @@ internal class CardFormModule(
           value?.addActivityResultListener(this)
       }
 
-    init {
-        register?.addActivityResultListener(this)
-    }
-
-    private fun currentActivity(): Activity? = register?.activity() ?: binding?.activity
+    private fun currentActivity(): Activity? = binding?.activity
 
     // handle MethodCall
 
@@ -106,12 +101,12 @@ internal class CardFormModule(
         }
         Payjp.cardForm().handleResult(data, object: PayjpCardFormResultCallback {
             override fun onResult(result: PayjpCardFormResult) {
-                if (result.isSuccess()) {
-                    channel.invokeMethod(ChannelContracts.ON_CARD_FORM_COMPLETED, null)
-                } else if (result.isCanceled()) {
-                    channel.invokeMethod(ChannelContracts.ON_CARD_FORM_CANCELED, null)
-                }
+            if (result.isSuccess()) {
+                channel.invokeMethod(ChannelContracts.ON_CARD_FORM_COMPLETED, null)
+            } else if (result.isCanceled()) {
+                channel.invokeMethod(ChannelContracts.ON_CARD_FORM_CANCELED, null)
             }
+        }
         })
         return true
     }

--- a/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
+++ b/android/src/main/kotlin/jp/pay/flutter/PayjpFlutterPlugin.kt
@@ -33,7 +33,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import jp.pay.android.Payjp
 import jp.pay.android.PayjpCardForm
 import jp.pay.android.PayjpConfiguration
@@ -46,11 +45,6 @@ import java.util.Locale
 class PayjpFlutterPlugin: MethodCallHandler, FlutterPlugin, ActivityAware {
   companion object {
     private const val CHANNEL_NAME = "payjp"
-    @Suppress("unused")
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      PayjpFlutterPlugin().setUpChannel(registrar.context(), registrar.messenger(), registrar)
-    }
   }
 
   private var channel: MethodChannel? = null
@@ -58,7 +52,7 @@ class PayjpFlutterPlugin: MethodCallHandler, FlutterPlugin, ActivityAware {
   private var cardFormModule: CardFormModule? = null
 
   override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    setUpChannel(binding.applicationContext, binding.binaryMessenger, null)
+    setUpChannel(binding.applicationContext, binding.binaryMessenger)
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -90,13 +84,12 @@ class PayjpFlutterPlugin: MethodCallHandler, FlutterPlugin, ActivityAware {
    */
   private fun setUpChannel(
     applicationContext: Context,
-    messenger: BinaryMessenger,
-    register: Registrar?
+    messenger: BinaryMessenger
   ) {
     this.applicationContext = applicationContext
     channel = MethodChannel(messenger, CHANNEL_NAME).also {
       it.setMethodCallHandler(this)
-      cardFormModule = CardFormModule(it, register)
+      cardFormModule = CardFormModule(it)
     }
   }
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -36,6 +36,7 @@
 **/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
+**/android/**/.cxx/
 
 # iOS/XCode related
 **/ios/**/*.mode1v3

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
     - GoogleUtilities/Privacy
   - integration_test (0.0.1):
     - Flutter
-  - payjp_flutter (0.7.2):
+  - payjp_flutter (0.7.4):
     - Flutter
     - GoogleUtilities/AppDelegateSwizzler (~> 8)
     - PAYJPFlutterCore (~> 2.1.5)
@@ -58,11 +58,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  payjp_flutter: a76d13639e12e70bc7d04b1f61a9904d14e95eb0
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
+  payjp_flutter: be8d4051af11793bfd20d7258888a57ce12910c1
   PAYJPFlutterCore: 51c8ca0b7cbcfeb668de5d098afffe472b8fca04
   PhoneNumberKit: a74155066daa6450475f6a029068eb919fb00d5d
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -50,6 +50,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/ios/Classes/PayjpPluginConstant.swift
+++ b/ios/Classes/PayjpPluginConstant.swift
@@ -12,5 +12,5 @@ struct PayjpPluginConstant {
     private init() {
     }
 
-    static let PluginVersion: String = "0.7.3"
+    static let PluginVersion: String = "0.7.4"
 }

--- a/ios/payjp_flutter.podspec
+++ b/ios/payjp_flutter.podspec
@@ -7,7 +7,7 @@ payjp_sdk = JSON.parse(File.read(File.join(__dir__, '../sdkconfig.json')))
 
 Pod::Spec.new do |s|
   s.name             = 'payjp_flutter'
-  s.version          = '0.7.3'
+  s.version          = '0.7.4'
   s.summary          = 'A Flutter plugin for PAY.JP Mobile SDK.'
   s.description      = <<-DESC
 A Flutter plugin for PAY.JP Mobile SDK.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: payjp_flutter
-version: 0.7.3
+version: 0.7.4
 description: A Flutter plugin for PAY.JP Mobile SDK.
 homepage: https://github.com/payjp/payjp-flutter-plugin
 repository: https://github.com/payjp/payjp-flutter-plugin


### PR DESCRIPTION
Flutter 3.29.0でプラグインをビルドするとAndroid embedding v1 APIの削除によりエラーが発生します。 参考：#88

これを解決するために v1 APIの参照をコードから削除します。これは既存のアプリの誤解性のために追加したコードでした。すでに公式プラグインからも削除されています。
参考：[Flutter Android Plugin v1 Embedding APIの廃止について](https://www.docswell.com/s/laiso/5J46J4-2025-02-15-164229)

<del>この変更後、v1 APIを利用するアプリはv2 APIへの移行が必要になります。
参考：[flutter/docs/platforms/android/Upgrading\-pre\-1\.12\-Android\-projects\.md at main · flutter/flutter](https://github.com/flutter/flutter/blob/main/docs/platforms/android/Upgrading-pre-1.12-Android-projects.md)</del>