### PR TITLE
Remove openapi submodule

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,3 +116,34 @@ jobs:
           xcrun simctl boot "${UDID}"
       - name: Run e2e test
         run: make driver-test
+
+  validate-openapi:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tool/generator
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache Node.js modules
+      uses: actions/cache@v1
+      with:
+        path: ~/.cache/yarn
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+    - name: Install dependencies
+      run: yarn --frozen-lockfile
+    - name: yarn validate
+      run: yarn validate
+      env:
+        CI: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tool/generator/openapi"]
-	path = tool/generator/openapi
-	url = git@github.com:payjp/openapi.git

--- a/tool/generator/README.md
+++ b/tool/generator/README.md
@@ -7,8 +7,3 @@ yarn install
 yarn bootstrap
 ```
 
-It has git submodule https://github.com/payjp/openapi.
-
-```shell
-git submodule update
-```

--- a/tool/generator/generate.sh
+++ b/tool/generator/generate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
 openapi-generator-cli generate \
--i openapi/token-api.yaml \
+-i token-api.yaml \
 -g dart-dio-next \
 -o project

--- a/tool/generator/package.json
+++ b/tool/generator/package.json
@@ -6,9 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "pull": "git submodule update",
     "bootstrap": "npm run generate && npm run fmt && npm run copy",
-    "validate": "openapi-generator-cli validate -i openapi/token-api.yaml",
+    "validate": "openapi-generator-cli validate -i token-api.yaml",
     "generate": "./generate.sh",
     "fmt": "dart format project/lib",
     "copy": "cp -r project/lib/src/model/* ../../lib/src",


### PR DESCRIPTION
- 権限がないとgit操作でエラーが出ていたため、プライベートなレポジトリに配置されていたOpen APIのyamlをこのレポジトリ内に移動
- 今後必要に応じて更新はするがこのtoken-api.yamlはあくまで当SDKのためだけに用意したもので、API側の刷新に必ず追従していくものではありません
- CIにyamlのvalidateジョブを追加