### PR TITLE
podspecからCardIOの記述削除

### DIFF
--- a/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
+++ b/example/ios/Flutter/ephemeral/flutter_lldb_helper.py
@@ -1,0 +1,32 @@
+#
+# Generated file, do not edit.
+#
+
+import lldb
+
+def handle_new_rx_page(frame: lldb.SBFrame, bp_loc, extra_args, intern_dict):
+    """Intercept NOTIFY_DEBUGGER_ABOUT_RX_PAGES and touch the pages."""
+    base = frame.register["x0"].GetValueAsAddress()
+    page_len = frame.register["x1"].GetValueAsUnsigned()
+
+    # Note: NOTIFY_DEBUGGER_ABOUT_RX_PAGES will check contents of the
+    # first page to see if handled it correctly. This makes diagnosing
+    # misconfiguration (e.g. missing breakpoint) easier.
+    data = bytearray(page_len)
+    data[0:8] = b'IHELPED!'
+
+    error = lldb.SBError()
+    frame.GetThread().GetProcess().WriteMemory(base, data, error)
+    if not error.Success():
+        print(f'Failed to write into {base}[+{page_len}]', error)
+        return
+
+def __lldb_init_module(debugger: lldb.SBDebugger, _):
+    target = debugger.GetDummyTarget()
+    # Caveat: must use BreakpointCreateByRegEx here and not
+    # BreakpointCreateByName. For some reasons callback function does not
+    # get carried over from dummy target for the later.
+    bp = target.BreakpointCreateByRegex("^NOTIFY_DEBUGGER_ABOUT_RX_PAGES$")
+    bp.SetScriptCallbackFunction('{}.handle_new_rx_page'.format(__name__))
+    bp.SetAutoContinue(True)
+    print("-- LLDB integration loaded --")

--- a/example/ios/Flutter/ephemeral/flutter_lldbinit
+++ b/example/ios/Flutter/ephemeral/flutter_lldbinit
@@ -1,0 +1,5 @@
+#
+# Generated file, do not edit.
+#
+
+command script import --relative-to-command-file flutter_lldb_helper.py

--- a/ios/payjp_flutter.podspec
+++ b/ios/payjp_flutter.podspec
@@ -21,9 +21,6 @@ A Flutter plugin for PAY.JP Mobile SDK.
   s.public_header_files = 'Classes/**/*.h'
   s.static_framework = true
   s.dependency 'PAYJPFlutterCore', "~> #{payjp_sdk['ios']}"
-  # NOTE: If you need to scan card in your card form, please add the following dependency to your Podfile directly.
-  # as default, we don't include this dependency because it causes a issue in arm64 simulator build.
-  # s.dependency 'CardIO', '~> 5.4.1'7.2'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 8'
   s.dependency 'Flutter'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## 概要

* Androidに合わせてカードスキャナープラグイン追加のコメント削除
* iOSは実装上に記述が見つからなかったので、podspecのコメント削除のみ

## 関連Issues

* https://github.com/payjp/payjp-android/issues/80


### 動作検証

* Pixel 7 Pro（emulator：Android 13）
    - [x] ビルド確認
    - [x] カード登録
* iPhone 16 Pro（simulator：iOS 18.1）
    - [x] ビルド確認
    - [x] カード登録
