### PR TITLE
upgrade actions node24

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -71,6 +71,12 @@ jobs:
       # build app
       - name: Build android app
         run: make build-android-example
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -l /dev/kvm
       - name: Run e2e test on Android Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,7 +131,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [22.x, 24.x]
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 30
     steps:
       # setup flutter
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 30
     steps:
       # setup flutter
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 30
     steps:
       # setup flutter
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ env.USER_JAVA_VERSION }}
@@ -128,9 +128,9 @@ jobs:
         node-version: [18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache Node.js modules

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -9,13 +9,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: '12.x'
-      - uses: subosito/flutter-action@v1
+          java-version: '17'
+          distribution: "zulu"
+      - uses: subosito/flutter-action@v2
       - run: flutter pub get
       - name: Cache Cocoapods
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: pods-cache
         with:
           path: example/ios/Pods

--- a/.github/workflows/check_dependencies_outdated.yml
+++ b/.github/workflows/check_dependencies_outdated.yml
@@ -8,7 +8,7 @@ jobs:
   check_outdated:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v1
         with:
           java-version: '12.x'

--- a/.github/workflows/check_latest_sdk.yml
+++ b/.github/workflows/check_latest_sdk.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           repository: payjp/payjp-android
           release-only: true
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Update with latest sdk
         run: |
           jq '. + { ios: "${{ steps.latest-ios.outputs.tag }}", android: "${{ steps.latest-android.outputs.tag }}"}' sdkconfig.json > tmp.json && mv tmp.json sdkconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build/
 *.iws
 .idea/
 example/ios/Flutter/.last_build_id
+
+# claude
+.serena

--- a/lib/src/payjp.dart
+++ b/lib/src/payjp.dart
@@ -28,8 +28,8 @@ typedef OnApplePayFailedRequestTokenCallback =
     FutureOr<CallbackResultError> Function(ErrorInfo errorInfo);
 typedef OnApplePayCompletedCallback = void Function();
 
-// ignore: avoid_classes_with_only_static_members
 /// Provides flutter bridge for PAY.JP.
+// ignore: avoid_classes_with_only_static_members
 class Payjp {
   static OnCardFormCanceledCallback? _onCardFormCanceledCallback;
   static OnCardFormCompletedCallback? _onCardFormCompletedCallback;


### PR DESCRIPTION
## 概要
GitHub ActionsランナーのNode.js 20が2026年4月にEOLとなり、2026年6月16日からNode 24がデフォルト化されます。
これに伴い、ワークフローで使用しているアクションをNode 24対応バージョンへ更新します。

また、修正とは無関係でしたが、ビルドに失敗する部分があったので、修正しております。
[d0b610c](https://github.com/payjp/payjp-flutter-plugin/pull/107/commits/d0b610c2e09328548ea7d7fc07c9d4af773c450a)
[6bdaca7](https://github.com/payjp/payjp-flutter-plugin/pull/107/commits/6bdaca7911601f54c6c71eacca584753ddd3c252)

## 変更点
### ■ 修正内容
GitHubのアクションをNode 24対応バージョンへ更新
### ■ 影響範囲
* リリースフローなどGitHubアクションがNode 24対応バージョンで実行される。
## 確認項目
* [x] ブランチ作成、masterマージ、リリース時にGitHubアクションが正常に終了すること